### PR TITLE
Fix XSS in the preview functionality

### DIFF
--- a/django_markdown/templates/django_markdown/preview.html
+++ b/django_markdown/templates/django_markdown/preview.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" type="text/css" href="{% static css %}" />
 </head>
 <body>
-{{ content|markdown }}
+{{ content|markdown_safe }}
 </body>
 </html>
 


### PR DESCRIPTION
By default this library uses the including preview page, which doesn't make use of the markdown_safe function. I changed the page to use markdown_safe so that this page wouldn't allow XSS by default.
