### PR TITLE
Fix Content Security Policy compatibility by removing inline script.

### DIFF
--- a/django_markdown/static/django_markdown/editor.js
+++ b/django_markdown/static/django_markdown/editor.js
@@ -1,0 +1,10 @@
+(function($) {
+    var config = JSON.parse($("#markItUpEditorConfig").text());
+    $(document).ready(function() {
+        $(config["selector"]).each(function (k, el) {
+            var el = $(el);
+            if(!el.hasClass("markItUpEditor")) el.markItUp(
+                mySettings, config["extra_settings"]);
+        });
+    });
+})(jQuery);

--- a/django_markdown/templates/django_markdown/editor_init.html
+++ b/django_markdown/templates/django_markdown/editor_init.html
@@ -1,11 +1,9 @@
-<script type="text/javascript">
-(function($) {
-    $(document).ready(function() {
-        $("{{ selector }}").each(function (k, el) {
-            var el = $(el);
-            if(!el.hasClass("markItUpEditor")) el.markItUp(
-                mySettings, {{ extra_settings|safe|default:"{}" }});
-        });
-    });
-})(jQuery);
+{% load django_markdown_static %}
+
+<script type="application/json" id="markItUpEditorConfig">
+{
+	"selector": "{{ selector }}",
+	"extra_settings": {{ extra_settings|safe|default:"{}" }}
+}
 </script>
+<script type="text/javascript" src="{% static 'django_markdown/editor.js' %}"></script>


### PR DESCRIPTION
In order to enforce an effective [CSP](https://en.wikipedia.org/wiki/Content_Security_Policy), sites must disallow the use of inline scripts, as they are a common exploit vector for attacks. Unfortunately, `django-markdown-app` uses an inline script to pass information to the front-end when rendering the `markItUpEditor` widget. This causes it to break when such a CSP is enforced.

This PR fixes the issue by moving the executed portion of the script to an external JavaScript file while serializing the data as JSON.