### PR TITLE
FIX: Multiple editors with different selectors/configs

### DIFF
--- a/django_markdown/static/django_markdown/editor.js
+++ b/django_markdown/static/django_markdown/editor.js
@@ -1,10 +1,11 @@
-(function($) {
-    var config = JSON.parse($("#markItUpEditorConfig").text());
-    $(document).ready(function() {
+jQuery(function ($) {
+    $('script.markItUpEditorConfig').each(function (i, config_element) {
+        var config = JSON.parse(config_element.textContent);
         $(config["selector"]).each(function (k, el) {
             var el = $(el);
-            if(!el.hasClass("markItUpEditor")) el.markItUp(
-                mySettings, config["extra_settings"]);
+            if(!el.hasClass("markItUpEditor")) {
+                el.markItUp(mySettings, config["extra_settings"]);
+            }
         });
     });
-})(jQuery);
+});

--- a/django_markdown/templates/django_markdown/editor_init.html
+++ b/django_markdown/templates/django_markdown/editor_init.html
@@ -1,9 +1,6 @@
-{% load django_markdown_static %}
-
-<script type="application/json" id="markItUpEditorConfig">
+<script type="application/json" class="markItUpEditorConfig">
 {
 	"selector": "{{ selector }}",
 	"extra_settings": {{ extra_settings|safe|default:"{}" }}
 }
 </script>
-<script type="text/javascript" src="{% static 'django_markdown/editor.js' %}"></script>

--- a/django_markdown/widgets.py
+++ b/django_markdown/widgets.py
@@ -48,7 +48,8 @@ class MarkdownWidget(forms.Textarea):
         js = (
             os.path.join('django_markdown', 'jquery.init.js'),
             os.path.join('django_markdown', 'jquery.markitup.js'),
-            os.path.join(settings.MARKDOWN_SET_PATH, settings.MARKDOWN_SET_NAME, 'set.js')
+            os.path.join(settings.MARKDOWN_SET_PATH, settings.MARKDOWN_SET_NAME, 'set.js'),
+            os.path.join('django_markdown', 'editor.js')
         )
 
 


### PR DESCRIPTION
#12 likely broke sites which include multiple editors on the same page. It used an id attribute to identify the JSON config element, which could result in only the first editor being initialized. This PR fixes that issue by instead using a class attribute, then iterating over the results.