### PR TITLE
Change import of deprecated reverse function

### DIFF
--- a/django_markdown/templatetags/django_markdown.py
+++ b/django_markdown/templatetags/django_markdown.py
@@ -2,7 +2,7 @@
 import posixpath
 
 from django import template
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from ..utils import markdown as _markdown, settings, simplejson

--- a/django_markdown/templatetags/django_markdown.py
+++ b/django_markdown/templatetags/django_markdown.py
@@ -2,7 +2,10 @@
 import posixpath
 
 from django import template
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Compatibility with previous Django version
+    from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 
 from ..utils import markdown as _markdown, settings, simplejson

--- a/django_markdown/utils.py
+++ b/django_markdown/utils.py
@@ -1,7 +1,11 @@
 """ Markdown utils. """
 import markdown as markdown_module
 
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Compatibility with previous Django version
+    from django.core.urlresolvers import reverse
+
 from django.template import loader
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe

--- a/django_markdown/utils.py
+++ b/django_markdown/utils.py
@@ -1,7 +1,7 @@
 """ Markdown utils. """
 import markdown as markdown_module
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template import loader
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe


### PR DESCRIPTION

import reverse function from `django.urls`

RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls