### PR TITLE
allow django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
 - "3.5"
 - "3.6"
+- "3.7"
 
 branches:
     only:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django>=2.0,<2.2
+Django>=2.0,<=2.2
 markdown>=2.6.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist=py36-d20,py36-d21,py35-d20,py35-d21,cov,flake8
+envlist=py36-d20,py36-d21,py37-d22,py35-d20,py35-d21,cov,flake8
 
 [tox:travis]
 3.5 = py35
 3.6 = py36, cov
+3.7 = py37
 
 [pylama]
 skip=example/*
@@ -36,22 +37,27 @@ commands=flake8 django_markdown
 
 [testenv:py35-d20]
 deps =
-    django==2.0.9
+    django==2.0.13
     {[testenv]deps}
 
 [testenv:py35-d21]
 deps =
-    django==2.1.4
+    django==2.1.8
     {[testenv]deps}
 
 [testenv:py36-d20]
 deps =
-    django==2.0.9
+    django==2.0.13
     {[testenv]deps}
 
 [testenv:py36-d21]
 deps =
-    django==2.1.4
+    django==2.1.8
+    {[testenv]deps}
+
+[testenv:py37-d22]
+deps =
+    django==2.2
     {[testenv]deps}
 
 [testenv:cov]


### PR DESCRIPTION
support Django 2.2 (LTS) so it can be installed with Pipenv.

(It seems to work fine... I'll look into the Travis failure when I get the chance unless anyone knows what the deal is)