### PR TITLE
Change force_text to force_str

### DIFF
--- a/django_markdown/utils.py
+++ b/django_markdown/utils.py
@@ -3,7 +3,7 @@ import markdown as markdown_module
 
 from django import VERSION
 from django.template import loader
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 
 from . import settings
@@ -35,7 +35,7 @@ def markdown(value, extensions=settings.MARKDOWN_EXTENSIONS,
 
     """
     return mark_safe(markdown_module.markdown(
-        force_text(value), extensions=extensions,
+        force_str(value), extensions=extensions,
         extension_configs=extension_configs, safe_mode=safe))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,19 @@ envlist=
     py36-d20
     py36-d21
     py36-d22
+    py36-d30
+    py36-d31
+    py36-d32
+    py38-d40
+    py38-d41
+    py38-d42
     cov
     flake8
 
 [tox:travis]
 3.6 = py36, cov
 3.7 = py37
+3.8 = py38
 
 [pylama]
 skip=example/*
@@ -51,6 +58,36 @@ deps =
 [testenv:py36-d22]
 deps =
     django<=2.3
+    {[testenv]deps}
+
+[testenv:py36-d30]
+deps =
+    django<3.1
+    {[testenv]deps}
+
+[testenv:py36-d31]
+deps =
+    django<3.2
+    {[testenv]deps}
+
+[testenv:py36-d32]
+deps =
+    django<3.3
+    {[testenv]deps}
+
+[testenv:py38-d40]
+deps =
+    django<4.1
+    {[testenv]deps}
+
+[testenv:py38-d41]
+deps =
+    django<=4.2
+    {[testenv]deps}
+
+[testenv:py38-d42]
+deps =
+    django<4.3
     {[testenv]deps}
 
 [testenv:cov]


### PR DESCRIPTION
Change removed method `force_text` to `force_str` for which it was an alias, for compatibility with Django <=4.2.9